### PR TITLE
修复星尘代理拉起的进程如有子进程时无法全部结束的问题

### DIFF
--- a/Stardust/Managers/ServiceController.cs
+++ b/Stardust/Managers/ServiceController.cs
@@ -445,7 +445,24 @@ internal class ServiceController : DisposeBase
             if (!p.GetHasExited())
             {
                 WriteLog("强行结束进程 PID={0}/{1}", p.Id, p.ProcessName);
-                p.Kill();
+                // 终止指定的进程及启动的子进程,如nginx等
+                // 在Core 3.0, Core 3.1, 5, 6, 7, 8, 9 中支持此重载
+                // https://learn.microsoft.com/zh-cn/dotnet/api/system.diagnostics.process.kill?view=net-8.0#system-diagnostics-process-kill(system-boolean)
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0 || NET7_0 || NET8_0 || NET9_0
+                p.Kill(true);
+#else
+                if (Runtime.Linux)
+                {
+                    //-9 SIGKILL 强制终止信号
+                    Process.Start("kill",$"-9 {p.Id}");
+                }
+                else if (Runtime.Windows)
+                {
+                    // /f 指定强制终止进程，有子进程时只能强制
+                    // /t 终止指定的进程和由它启用的子进程 
+                    Process.Start("taskkill", $"/t /f /pid {p.Id}");
+                }               
+#endif
             }
 
             if (p.GetHasExited()) WriteLog("进程[PID={0}]已退出！ExitCode={1}", p.Id, p.ExitCode);


### PR DESCRIPTION
问题：
当星尘代理拉起的应用存在子进程时，此时如果要停止或重启应用，无法正确的停止所有进程 ，如Nginx有两个worker，此时结束应用只能关掉一个进程，再启动时就会存在三个进程的现象。

修复前：
![nginxAfterStop](https://github.com/NewLifeX/Stardust/assets/5615543/6ea0c8da-828c-4bfe-9518-677ed0144f20)

![subp](https://github.com/NewLifeX/Stardust/assets/5615543/d77bd834-dda2-445c-80e5-d74d5ee1fbcd)

修复后：

![nginx-restart](https://github.com/NewLifeX/Stardust/assets/5615543/5f384072-9bd2-4c95-bb9f-7331ebc0d58a)

