### PR TITLE
修复路径相关问题

### DIFF
--- a/Stardust/Managers/ServiceController.cs
+++ b/Stardust/Managers/ServiceController.cs
@@ -157,11 +157,8 @@ internal class ServiceController : DisposeBase
                         if (deploy == null) throw new Exception("解压缩失败");
 
                         //file ??= deploy.ExecuteFile;
-                        if (file.IsNullOrEmpty())
-                        {
-                            var runfile = deploy.FindExeFile(workDir);
-                            file = runfile?.FullName;
-                        }
+                        var runfile = deploy.FindExeFile(workDir);
+                        file = runfile?.FullName;
                         if (file.IsNullOrEmpty()) throw new Exception("无法找到启动文件");
 
                         args = deploy.Arguments;


### PR DESCRIPTION
本PR主要修复两个路径相关的问题，具体如下

1. 假设根目录为E:\Stardust，子目录结构如下

```
Stardust 
   --Agent
      --StarAgent.exe
      --StarAgent.dll
	  
   --Job
      --Job.exe
      --job.ini
      --Job2.exe
      --job2.ini
	  
    --Shadow 

```

应用部署设置为
 
```
 "Service": {
      "Name": "Job",
      "FileName": "job",
      "Arguments": "-c ./job.ini",
      "WorkingDirectory": "../Job",
      "UserName": null,
      "Enable": true,
      "Mode": 2,
      "MaxMemory": 0
    }
```

部署应用名Job，此时如果FileName仅使用job不包括后缀.exe(在windows下)，星尘代理则会启动失败至最大尝试次数。

因为我这边部署的应用为有非托管实现，带后缀的话跨平台部署会有问题。

修改前运行日志片段

```
00:05:14.848 17 Y T [2/Job]启动应用：job -c ./job.ini workDir=E:\Stardust\Job Mode=ExtractAndRun Times=18
00:05:14.848 17 Y T [2/Job]解压后在工作目录运行
00:05:14.849 17 Y T [2/Job]解压缩 E:\Stardust\Job\Job.zip 到 E:\Stardust\shadow\Job-20240510000514
00:05:14.895 17 Y T [2/Job]清空运行目录可执行文件：E:\Stardust\Job
00:05:14.897 17 Y T [2/Job]拷贝文件到运行目录：E:\Stardust\Job
00:05:14.902 17 Y T [2/Job]删除临时影子目录：E:\Stardust\shadow\Job-20240510000514
00:05:14.904 17 Y T [2/Job]拉起进程：job -c ./job.ini
00:05:14.905 17 Y T [2/Job]工作目录: E:\Stardust\Job
00:05:14.906 17 Y T [2/Job]启动文件: job
00:05:14.906 17 Y T [2/Job]启动参数: -c ./job.ini
00:05:14.908 17 Y T System.ComponentModel.Win32Exception (2): An error occurred trying to start process 'job' with working directory 'E:\Stardust\Job'. 系统找不到指定的文件。
   at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at Stardust.Managers.ServiceController.RunExe(String file, String args, String workDir, ServiceInfo service)
   at Stardust.Managers.ServiceController.Start()
```
	
修改后运行日志片段

```
01:10:47.054 15 Y TP [3/Job]启动应用：job -c ./job.ini workDir=E:\Stardust\Job\ Mode=ExtractAndRun Times=1
01:10:47.055 15 Y TP [3/Job]解压后在工作目录运行
01:10:47.059 15 Y TP [3/Job]解压缩 E:\Stardust\Job\Job.zip 到 E:\Stardust\shadow\Job-20240510011047
01:10:47.118 15 Y TP [3/Job]清空运行目录可执行文件：E:\Stardust\Job
01:10:47.120 15 Y TP [3/Job]跳过同目录可执行文件：E:\Stardust\Job\job2.exe
01:10:47.122 15 Y TP [3/Job]可执行文件：E:\Stardust\Job\job.exe
01:10:47.123 15 Y TP [3/Job]拷贝文件到运行目录：E:\Stardust\Job
01:10:47.156 15 Y TP [3/Job]删除临时影子目录：E:\Stardust\shadow\Job-20240510011047
01:10:47.161 15 Y TP [3/Job]拉起进程：E:\Stardust\Job\job.exe -c ./job.ini
01:10:47.162 15 Y TP [3/Job]工作目录: E:\Stardust\Job\
01:10:47.162 15 Y TP [3/Job]启动文件: E:\Stardust\Job\job.exe
01:10:47.163 15 Y TP [3/Job]启动参数: -c ./job.ini
01:10:50.282 15 Y TP [3/Job]启动成功 PID=14508/job
```


2. 我这边有同目录下运行多个可执行文件的情况，目前解压时会清理目录下所有可执行文件，除当前部署的可执行程序外其它的也在运行，所以此时删除其它在运行的应用肯定也会失败。

修改前运行日志片段

```
00:14:31.939  9 Y T [2/Job]启动应用：job -c ./job.ini workDir=E:\Stardust\Job Mode=ExtractAndRun Times=1
00:14:31.940  9 Y T [2/Job]解压后在工作目录运行
00:14:31.941  9 Y T [2/Job]解压缩 E:\Stardust\Job\Job.zip 到 E:\Stardust\shadow\Job-20240510001431
00:14:31.986  9 Y T [2/Job]清空运行目录可执行文件：E:\Stardust\Job

00:14:31.988  9 Y T [2/Job]**Access to the path 'E:\Stardust\Job\job2.exe' is denied.**

00:14:31.989  9 Y T [2/Job]拷贝文件到运行目录：E:\Stardust\Job
00:14:31.994  9 Y T [2/Job]删除临时影子目录：E:\Stardust\shadow\Job-20240510001431
00:14:31.995  9 Y T [2/Job]拉起进程：E:\Stardust\Job\job.exe -c ./job.ini
00:14:31.999  9 Y T [2/Job]工作目录: E:\Stardust\Job
00:14:31.999  9 Y T [2/Job]启动文件: E:\Stardust\Job\job.exe
00:14:32.000  9 Y T [2/Job]启动参数: -c ./job.ini
00:14:35.110  9 Y T [2/Job]启动成功 PID=27516/job
```

修改后运行日志片段

```
01:10:47.054 15 Y TP [3/Job]启动应用：job -c ./job.ini workDir=E:\Stardust\Job\ Mode=ExtractAndRun Times=1
01:10:47.055 15 Y TP [3/Job]解压后在工作目录运行
01:10:47.059 15 Y TP [3/Job]解压缩 E:\Stardust\Job\Job.zip 到 E:\Stardust\shadow\Job-20240510011047
01:10:47.118 15 Y TP [3/Job]清空运行目录可执行文件：E:\Stardust\Job
01:10:47.120 15 Y TP [3/Job]跳过同目录可执行文件：E:\Stardust\Job\job2.exe
01:10:47.122 15 Y TP [3/Job]可执行文件：E:\Stardust\Job\job.exe
01:10:47.123 15 Y TP [3/Job]拷贝文件到运行目录：E:\Stardust\Job
01:10:47.156 15 Y TP [3/Job]删除临时影子目录：E:\Stardust\shadow\Job-20240510011047
01:10:47.161 15 Y TP [3/Job]拉起进程：E:\Stardust\Job\job.exe -c ./job.ini
01:10:47.162 15 Y TP [3/Job]工作目录: E:\Stardust\Job\
01:10:47.162 15 Y TP [3/Job]启动文件: E:\Stardust\Job\job.exe
01:10:47.163 15 Y TP [3/Job]启动参数: -c ./job.ini
01:10:50.282 15 Y TP [3/Job]启动成功 PID=14508/job
```

如有不妥之处请指正。