### PR TITLE
增加对应用部署版本策略的支持

### DIFF
--- a/Stardust.Data/Deployment/Model.xml
+++ b/Stardust.Data/Deployment/Model.xml
@@ -117,6 +117,7 @@
         <Column Name="DeployId" ColumnName="AppId" DataType="Int32" Map="AppDeploy@Id@$" Description="应用部署集。对应AppDeploy" />
         <Column Name="Version" DataType="String" Master="True" Nullable="False" Description="版本。如2.3.2022.0911，字符串比较大小" />
         <Column Name="Enable" DataType="Boolean" Description="启用" />
+	<Column Name="Strategy" DataType="String" Length="500" Description="策略。升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version&gt;=1.0;runtime/framework/os/oskind/arch/province/city" />
         <Column Name="Url" DataType="String" ItemType="file" Length="500" Description="资源地址。一般打包为Zip包，StarAgent下载后解压缩覆盖" />
         <Column Name="Overwrite" DataType="String" Length="100" Description="覆盖文件。需要拷贝覆盖已存在的文件或子目录，支持*模糊匹配，多文件分号隔开。如果目标文件不存在，配置文件等自动拷贝" />
         <Column Name="Size" DataType="Int64" ItemType="GMK" Description="文件大小" />

--- a/Stardust.Data/Deployment/Stardust.htm
+++ b/Stardust.Data/Deployment/Stardust.htm
@@ -742,6 +742,17 @@
             <td>N</td>
             <td></td>
         </tr>
+		
+		<tr>
+            <td>Strategy</td>
+            <td>策略</td>
+            <td>String</td>
+            <td>500</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version>=1.0;runtime/framework/os/oskind/arch/province/city</td>
+        </tr>
 
         <tr>
             <td>Url</td>

--- a/Stardust.Data/Deployment/部署版本.cs
+++ b/Stardust.Data/Deployment/部署版本.cs
@@ -54,6 +54,14 @@ public partial class AppDeployVersion
     [BindColumn("Enable", "启用", "")]
     public Boolean Enable { get => _Enable; set { if (OnPropertyChanging("Enable", value)) { _Enable = value; OnPropertyChanged("Enable"); } } }
 
+    private String _Strategy;
+    /// <summary>策略。升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version>=1.0;runtime/framework/os/oskind/arch/province/city</summary>
+    [DisplayName("策略")]
+    [Description("策略。升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version>=1.0;runtime/framework/os/oskind/arch/province/city")]
+    [DataObjectField(false, false, true, 500)]
+    [BindColumn("Strategy", "策略。升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version>=1.0;runtime/framework/os/oskind/arch/province/city", "varchar(500)")]
+    public String Strategy { get => _Strategy; set { if (OnPropertyChanging("Strategy", value)) { _Strategy = value; OnPropertyChanged("Strategy"); } } }
+
     private String _Url;
     /// <summary>资源地址。一般打包为Zip包，StarAgent下载后解压缩覆盖</summary>
     [DisplayName("资源地址")]
@@ -206,6 +214,7 @@ public partial class AppDeployVersion
             "DeployId" => _DeployId,
             "Version" => _Version,
             "Enable" => _Enable,
+            "Strategy" => _Strategy,
             "Url" => _Url,
             "Overwrite" => _Overwrite,
             "Size" => _Size,
@@ -232,6 +241,7 @@ public partial class AppDeployVersion
                 case "DeployId": _DeployId = value.ToInt(); break;
                 case "Version": _Version = Convert.ToString(value); break;
                 case "Enable": _Enable = value.ToBoolean(); break;
+                case "Strategy": _Strategy = Convert.ToString(value); break;
                 case "Url": _Url = Convert.ToString(value); break;
                 case "Overwrite": _Overwrite = Convert.ToString(value); break;
                 case "Size": _Size = value.ToLong(); break;
@@ -281,6 +291,8 @@ public partial class AppDeployVersion
         /// <summary>启用</summary>
         public static readonly Field Enable = FindByName("Enable");
 
+        /// <summary>策略。升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version>=1.0;runtime/framework/os/oskind/arch/province/city</summary>
+        public static readonly Field Strategy = FindByName("Strategy");
         /// <summary>资源地址。一般打包为Zip包，StarAgent下载后解压缩覆盖</summary>
         public static readonly Field Url = FindByName("Url");
 
@@ -346,6 +358,9 @@ public partial class AppDeployVersion
 
         /// <summary>启用</summary>
         public const String Enable = "Enable";
+
+        /// <summary>策略。升级策略，版本特别支持大于等于和小于等于，node=*abcd*;version>=1.0;runtime/framework/os/oskind/arch/province/city</summary>
+        public const String Strategy = "Strategy";
 
         /// <summary>资源地址。一般打包为Zip包，StarAgent下载后解压缩覆盖</summary>
         public const String Url = "Url";

--- a/Stardust/Deployment/ZipDeploy.cs
+++ b/Stardust/Deployment/ZipDeploy.cs
@@ -85,6 +85,12 @@ public class ZipDeploy
             }
             else
             {
+                // 参数中如有路径根据工作目录进行补全
+                if (args[i].Contains('/') || args[i].Contains('\\'))
+                {
+                    args[i] = PathHelper.CombinePath(WorkingDirectory, args[i]).GetFullPath();
+                    WriteLog("参数路径补全 {0}", args[i]);
+                }
                 // 其它参数全要，支持 urls=http://*:8000
                 gs[i] = args[i];
             }
@@ -333,7 +339,7 @@ public class ZipDeploy
                         && !Path.GetFileNameWithoutExtension(item.Name).EqualIgnoreCase(
                            Path.GetFileNameWithoutExtension(fileName)))
                     {
-                        WriteLog("跳过同目录可执行文件：{0}", item.FullName);
+                        //WriteLog("跳过同目录可执行文件：{0}", item.FullName);
                         continue;
                     }
                     else

--- a/Stardust/Managers/ServiceManager.cs
+++ b/Stardust/Managers/ServiceManager.cs
@@ -384,6 +384,12 @@ public class ServiceManager : DisposeBase
         // 过滤应用
         if (!appName.IsNullOrEmpty()) rs = rs.Where(e => e.Name.EqualIgnoreCase(appName)).ToArray();
 
+        if (!rs.Any())  
+        {
+            WriteLog("无法从服务器取得可用的应用信息，请检查部署版本策略");
+            return null;
+        }
+
         WriteLog("取得应用服务：{0}", rs.Join(",", e => e.Name));
         WriteLog("可用：{0}", rs.Where(e => e.Service != null && e.Service.Enable).Join(",", e => e.Name));
         if (rs.Length > 0) WriteLog(rs.ToJson(true));


### PR DESCRIPTION
**场景：**
         假如现在有非托管应用Relay，现有Windows/Linux/Arm64等平台要部署。如果用现有版本星尘去部署，
        做法可能得是建立分别RealyWindow/RelayLinux/RelayArm64三个应用，然后分别添加对应平台的
        二进制应用进行发布，这么做倒是可以但不大灵活。

**实现：**       
       仿节点版本的做法进行改造，实现只添加一个应用，然后客户端根据设定的策略自动拉取正确的应用进行部署。

**效果：**

![add](https://github.com/NewLifeX/Stardust/assets/5615543/5cb1f29b-4679-4155-9da3-d563618fa13f)


     
![list](https://github.com/NewLifeX/Stardust/assets/5615543/27ee48f1-a33a-4223-98d4-e3b0864cc952)
  
以上改动我这边已测试通过，各位有兴趣的朋友可以拉取试一下，如发现问题请指正！